### PR TITLE
Param ctrl

### DIFF
--- a/designs/spinnaker_fpgas/README.md
+++ b/designs/spinnaker_fpgas/README.md
@@ -165,6 +165,24 @@ address: 0x00040000
 	                                   , 1: FORCE_ERROR_B2B1
 	                                   , 0: FORCE_ERROR_B2B0
 	                                   }
+	RXEQ       7   0x1C  RW         8  rx equalization (default: 0x0A)
+                                           { 7-6: RING_RXEQMIX
+                                           , 5-4: PERIPH_RXEQMIX
+                                           , 3-2: B2B1_RXEQMIX
+                                           , 1-0: B2B0_RXEQMIX
+                                           }
+	TXDS       7   0x20  RW        16  tx driver swing (default: 0x0077)
+                                           { 15-12: RING_TXDIFFCTRL
+                                           ,  11-8: PERIPH_TXDIFFCTRL
+                                           ,   7-4: B2B1_TXDIFFCTRL
+                                           ,   3-0: B2B0_TXDIFFCTRL
+                                           }
+	TXPE       7   0x24  RW        12  tx pre-emphasis (default: 0x00A)
+                                           { 11-9: RING_TXPREEMPHASIS
+                                           ,  8-6: PERIPH_TXPREEMPHASIS
+                                           ,  5-3: B2B1_TXPREEMPHASIS
+                                           ,  2-0: B2B0_TXPREEMPHASIS
+                                           }
 
 Note that disabling a link with the SLEN register tristates the associated link
 pins and holds in reset the corresponding SpiNNaker link interface block in the
@@ -186,6 +204,16 @@ indicating that the device has been configured and is ready to use. The `DIM_*`
 bits of LEDO cause the specified LEDs to be dimmed. It is suggested that when
 the 2-of-7 link exposed by SpiNN-5 boards is not being driven by the FPGA the
 corresponding LED is dimmed.
+
+Registers RXEQ, TXDV and TXPE can be used to set/overrride the high-speed
+receiver and transmitter analog parameters described in the Xilinx Spartan6
+documentation. The documentation also contains the parameter values and
+encodings. Incorrect settings may affect the operation of the high-speed
+links. The chosen default values for the board-to-board links have been tested
+and work correctly in many different board configurations and should not be
+changed without good cause. The peripheral and ring link parameters are not
+set and, therefore, need to be set by the user. The default board-to-board
+values may be a good starting point.
 
 Finally, there is a set of counters associated to every SpiNNaker - FPGA link.
 

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
@@ -42,7 +42,44 @@ module spinnaker_fpgas_reg_bank #( // Address bits
                                    //     , FORCE_ERROR_B2B0
                                    //     }
                                  , output reg              [7:0] LED_OVERRIDE
+                                   // rx equalization
+                                   //   {RING_RXEQMIX
+                                   //   , PERIPH_RXEQMIX
+                                   //   , B2B_RXEQMIX
+                                   //   , B2B_RXEQMIX
+                                   //   };
+                                 , output reg              [7:0] RXEQMIX
+                                   // tx driver swing
+                                   //   {RING_TXDIFFCTRL
+                                   //   , PERIPH_TXDIFFCTRL
+                                   //   , B2B_TXDIFFCTRL
+                                   //   , B2B_TXDIFFCTRL
+                                   //   };
+                                 , output reg             [15:0] TXDIFFCTRL
+                                   // tx pre-emphasis
+                                   //   {RING_TXPREEMPHASIS
+                                   //   , PERIPH_TXPREEMPHASIS
+                                   //   , B2B_TXPREEMPHASIS
+                                   //   , B2B_TXPREEMPHASIS
+                                   //   };
+                                 , output reg             [11:0] TXPREEMPHASIS
                                  );
+
+// GTP Analog signal generation settings (either found via IBERT or left as zeros)
+localparam    B2B_RXEQMIX = 2'b10;   // 5.4 dB
+localparam PERIPH_RXEQMIX = 2'b00;   // Default
+localparam   RING_RXEQMIX = 2'b00;   // Default
+
+// !!lap localparam    B2B_TXDIFFCTRL = 4'b0010; // 495 mV
+// !!lap localparam    B2B_TXDIFFCTRL = 4'b0110; // 762 mV
+localparam    B2B_TXDIFFCTRL = 4'b0111; // 849 mV
+// !!lap localparam    B2B_TXDIFFCTRL = 4'b1010; // 1054 mV
+localparam PERIPH_TXDIFFCTRL = 4'b0000; // Default
+localparam   RING_TXDIFFCTRL = 4'b0000; // Default
+
+localparam    B2B_TXPREEMPHASIS = 3'b010;  // 1.7 dB
+localparam PERIPH_TXPREEMPHASIS = 3'b000;  // Default
+localparam   RING_TXPREEMPHASIS = 3'b000;  // Default
 
 localparam VERS_REG = 0; // Top level design version
 localparam FLAG_REG = 1; // Compile flags {   5: chip scope
@@ -64,6 +101,21 @@ localparam LEDO_REG = 6; // LED link override { 7: DIM_RING
                          //                   , 1: FORCE_ERROR_B2B1
                          //                   , 0: FORCE_ERROR_B2B0
                          //                   }
+localparam RXEQ_REG = 7; // rx equalization   { 7-6: RING_RXEQMIX
+                         //                   , 5-4: PERIPH_RXEQMIX
+                         //                   , 3-2: B2B1_RXEQMIX
+                         //                   , 1-0: B2B0_RXEQMIX
+                         //                   }
+localparam TXDS_REG = 8; // tx driver swing   { 15-12: RING_TXDIFFCTRL
+                         //                   ,  11-8: PERIPH_TXDIFFCTRL
+                         //                   ,   7-4: B2B1_TXDIFFCTRL
+                         //                   ,   3-0: B2B0_TXDIFFCTRL
+                         //                   }
+localparam TXPE_REG = 9; // tx pre-emphasis   { 11-9: RING_TXPREEMPHASIS
+                         //                   ,  8-6: PERIPH_TXPREEMPHASIS
+                         //                   ,  5-3: B2B1_TXPREEMPHASIS
+                         //                   ,  2-0: B2B0_TXPREEMPHASIS
+                         //                   }
 
 
 // Write address decode
@@ -75,6 +127,21 @@ always @ (posedge CLK_IN, posedge RESET_IN)
 			SCRMBL_IDL_DAT <= 32'hFFFFFFFF;
 			SPINNAKER_LINK_ENABLE <= 32'h00000000;
 			LED_OVERRIDE <= 8'h0F;
+			RXEQMIX <= {RING_RXEQMIX
+			           , PERIPH_RXEQMIX
+			           , B2B_RXEQMIX
+			           , B2B_RXEQMIX
+			           };
+			TXDIFFCTRL <= {RING_TXDIFFCTRL
+			              , PERIPH_TXDIFFCTRL
+			              , B2B_TXDIFFCTRL
+			              , B2B_TXDIFFCTRL
+			              };
+			TXPREEMPHASIS <= {RING_TXPREEMPHASIS
+			                 , PERIPH_TXPREEMPHASIS
+			                 , B2B_TXPREEMPHASIS
+			                 , B2B_TXPREEMPHASIS
+			                 };
 		end
 	else
 		if (WRITE_IN)
@@ -84,6 +151,9 @@ always @ (posedge CLK_IN, posedge RESET_IN)
 				SCRM_REG: SCRMBL_IDL_DAT <= WRITE_DATA_IN;
 				SLEN_REG: SPINNAKER_LINK_ENABLE <= WRITE_DATA_IN;
 				LEDO_REG: LED_OVERRIDE <= WRITE_DATA_IN;
+				RXEQ_REG: RXEQMIX <= WRITE_DATA_IN;
+				TXDS_REG: TXDIFFCTRL <= WRITE_DATA_IN;
+				TXPE_REG: TXPREEMPHASIS <= WRITE_DATA_IN;
 			endcase
 
 
@@ -97,6 +167,9 @@ always @ (*)
 		SCRM_REG: READ_DATA_OUT = SCRMBL_IDL_DAT;
 		SLEN_REG: READ_DATA_OUT = SPINNAKER_LINK_ENABLE;
 		LEDO_REG: READ_DATA_OUT = LED_OVERRIDE;
+		RXEQ_REG: READ_DATA_OUT = RXEQMIX;
+		TXDS_REG: READ_DATA_OUT = TXDIFFCTRL;
+		TXPE_REG: READ_DATA_OUT = TXPREEMPHASIS;
 		default:  READ_DATA_OUT = {REGD_BITS{1'b1}};
 	endcase
 

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
@@ -71,8 +71,8 @@ localparam PERIPH_RXEQMIX = 2'b00;   // Default
 localparam   RING_RXEQMIX = 2'b00;   // Default
 
 // !!lap localparam    B2B_TXDIFFCTRL = 4'b0010; // 495 mV
-// !!lap localparam    B2B_TXDIFFCTRL = 4'b0110; // 762 mV
-localparam    B2B_TXDIFFCTRL = 4'b0111; // 849 mV
+lap localparam    B2B_TXDIFFCTRL = 4'b0110; // 762 mV
+// !!localparam    B2B_TXDIFFCTRL = 4'b0111; // 849 mV
 // !!lap localparam    B2B_TXDIFFCTRL = 4'b1010; // 1054 mV
 localparam PERIPH_TXDIFFCTRL = 4'b0000; // Default
 localparam   RING_TXDIFFCTRL = 4'b0000; // Default

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -40,7 +40,7 @@ module spinnaker_fpgas_top #( // Version number for top-level design
                               // J9 and J11 on the front respectively.
                               // (peripheral connections will be placed on the
                               // opposing side).
-                            , parameter NORTH_SOUTH_ON_FRONT = 2
+                            , parameter NORTH_SOUTH_ON_FRONT = 1
                               // The interval at which clock correction sequences should
                               // be inserted (in cycles).
                             , parameter    B2B_CLOCK_CORRECTION_INTERVAL = 1000

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -40,7 +40,7 @@ module spinnaker_fpgas_top #( // Version number for top-level design
                               // J9 and J11 on the front respectively.
                               // (peripheral connections will be placed on the
                               // opposing side).
-                            , parameter NORTH_SOUTH_ON_FRONT = 1
+                            , parameter NORTH_SOUTH_ON_FRONT = 2
                               // The interval at which clock correction sequences should
                               // be inserted (in cycles).
                             , parameter    B2B_CLOCK_CORRECTION_INTERVAL = 1000
@@ -101,25 +101,20 @@ localparam    B2B_GTP_LOOPBACK = 3'b000;
 localparam PERIPH_GTP_LOOPBACK = 3'b000;
 localparam   RING_GTP_LOOPBACK = 3'b000;
 
-// GTP Analog signal generation settings (either found via IBERT or left as zeros)
-localparam    B2B_RXEQMIX = 2'b10;   // 5.4 dB
-localparam PERIPH_RXEQMIX = 2'b00;   // Default
-localparam   RING_RXEQMIX = 2'b00;   // Default
-
-// !!lap localparam    B2B_TXDIFFCTRL = 4'b0010; // 495 mV
-localparam    B2B_TXDIFFCTRL = 4'b0110; // 762 mV
-// !!lap localparam    B2B_TXDIFFCTRL = 4'b1010; // 1054 mV
-localparam PERIPH_TXDIFFCTRL = 4'b0000; // Default
-localparam   RING_TXDIFFCTRL = 4'b0000; // Default
-
-localparam    B2B_TXPREEMPHASIS = 3'b010;  // 1.7 dB
-localparam PERIPH_TXPREEMPHASIS = 3'b000;  // Default
-localparam   RING_TXPREEMPHASIS = 3'b000;  // Default
+////////////////////////////////////////////////////////////////////////////////
+// analog parameters moved to register bank -- now controlled by registers!
+////////////////////////////////////////////////////////////////////////////////
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // Internal signals
 ////////////////////////////////////////////////////////////////////////////////
+
+// analog parameters controlled from registers
+wire  [7:0] rxeqmix_i;
+wire [15:0] txdiffctrl_i;
+wire [11:0] txpreemphasis_i;
+
 
 // External reset signal
 wire n_reset_i;
@@ -733,12 +728,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[0])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[1])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              (B2B_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (B2B_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           (B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        (B2B_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (B2B_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[1:0])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[3:2])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[3:0])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[7:4])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[2:0])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[5:3])
 		             );
 	
 	{1, 0}:
@@ -808,12 +803,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[0])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[1])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              (   B2B_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (PERIPH_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           (   B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (PERIPH_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        (   B2B_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (PERIPH_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[1:0])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[5:4])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[3:0])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[11:8])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[2:0])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[8:6])
 		             );
 	
 	{1, 2}:
@@ -883,12 +878,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[0])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[1])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              (PERIPH_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (   B2B_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           (PERIPH_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (   B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        (PERIPH_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (   B2B_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[5:4])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[3:2])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[11:8])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[7:4])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[8:6])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[5:3])
 		             );
 endcase endgenerate
 
@@ -963,12 +958,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[2])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[3])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              (PERIPH_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (  RING_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           (PERIPH_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (  RING_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        (PERIPH_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (  RING_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[5:4])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[7:6])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[11:8])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[15:12])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[8:6])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[11:9])
 		            );
 	
 	{1, 0}:
@@ -1038,12 +1033,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[2])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[3])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              ( B2B_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (RING_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           ( B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (RING_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        ( B2B_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (RING_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[3:2])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[7:6])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[7:4])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[15:12])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[5:3])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[11:9])
 		            );
 	
 	{1, 2}:
@@ -1113,12 +1108,12 @@ generate case ({NORTH_SOUTH_ON_FRONT, FPGA_ID})
 		             ,   .TILE0_TXP0_OUT             (HSS_TXP_OUT[2])
 		             ,   .TILE0_TXP1_OUT             (HSS_TXP_OUT[3])
 		                 // Analog signal generation settings
-		             ,   .TILE0_RXEQMIX0_IN              ( B2B_RXEQMIX)
-		             ,   .TILE0_RXEQMIX1_IN              (RING_RXEQMIX)
-		             ,   .TILE0_TXDIFFCTRL0_IN           ( B2B_TXDIFFCTRL)
-		             ,   .TILE0_TXDIFFCTRL1_IN           (RING_TXDIFFCTRL)
-		             ,   .TILE0_TXPREEMPHASIS0_IN        ( B2B_TXPREEMPHASIS)
-		             ,   .TILE0_TXPREEMPHASIS1_IN        (RING_TXPREEMPHASIS)
+		             ,   .TILE0_RXEQMIX0_IN          (rxeqmix_i[1:0])
+		             ,   .TILE0_RXEQMIX1_IN          (rxeqmix_i[7:6])
+		             ,   .TILE0_TXDIFFCTRL0_IN       (txdiffctrl_i[3:0])
+		             ,   .TILE0_TXDIFFCTRL1_IN       (txdiffctrl_i[15:12])
+		             ,   .TILE0_TXPREEMPHASIS0_IN    (txpreemphasis_i[2:0])
+		             ,   .TILE0_TXPREEMPHASIS1_IN    (txpreemphasis_i[11:9])
 		            );
 endcase endgenerate
 
@@ -1708,6 +1703,9 @@ spinnaker_fpgas_reg_bank_i( .CLK_IN         (reg_bank_clk_i)
                           , .PERIPH_MC_MASK (periph_mc_mask_i)
                           , .SCRMBL_IDL_DAT (scrmbl_idl_dat_i)
                           , .LED_OVERRIDE   (led_override_i)
+                          , .RXEQMIX        (rxeqmix_i)
+                          , .TXDIFFCTRL     (txdiffctrl_i)
+                          , .TXPREEMPHASIS  (txpreemphasis_i)
                           );
 
 


### PR DESCRIPTION
New FPGA registers RXEQ, TXDV and TXPE can be used to set/overrride the high-speed receiver and transmitter analog parameters described in the Xilinx Spartan6 documentation.
