### PR TITLE
Code cleanup

### DIFF
--- a/designs/raggedstone_spinn_aer_if/raggedstone_spinn_aer_if_debouncer.v
+++ b/designs/raggedstone_spinn_aer_if/raggedstone_spinn_aer_if_debouncer.v
@@ -48,6 +48,13 @@ module raggedstone_spinn_aer_if_debouncer
   // ---------------------------------------------------------
   // generate stable output signal after suitable delay
   // ---------------------------------------------------------
+  // for simulation purposes only!
+  initial
+    begin
+      pb_debounced = RESET_VALUE;
+      pb_debounce_cnt = DBNCER_CONST;
+    end
+
   always @(posedge clk or posedge rst)
     if (rst)
       pb_debounced <= RESET_VALUE;

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_reg_bank.v
@@ -29,7 +29,7 @@ module spinnaker_fpgas_reg_bank #( // Address bits
                                    // Peripheral routing key/mask
                                  , output reg             [31:0] PERIPH_MC_KEY
                                  , output reg             [31:0] PERIPH_MC_MASK
-                                 , output reg             [31:0] SCRMBL_IDL_DAT
+                                 , output reg              [3:0] SCRMBL_IDL_DAT
                                    // Status LED overrides (for indicating
                                    // configuration status of the FPGA)
                                    //     { DIM_RING
@@ -124,7 +124,7 @@ always @ (posedge CLK_IN, posedge RESET_IN)
 		begin
 			PERIPH_MC_KEY  <= 32'hFFFFFFFF;
 			PERIPH_MC_MASK <= 32'h00000000;
-			SCRMBL_IDL_DAT <= 32'hFFFFFFFF;
+			SCRMBL_IDL_DAT <=  4'hF;
 			SPINNAKER_LINK_ENABLE <= 32'h00000000;
 			LED_OVERRIDE <= 8'h0F;
 			RXEQMIX <= {RING_RXEQMIX

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -333,7 +333,7 @@ wire [31:0] periph_mc_key_i;
 wire [31:0] periph_mc_mask_i;
 
 // control wires from the top-level register bank
-wire [31:0] scrmbl_idl_dat_i;
+wire [3:0] scrmbl_idl_dat_i;
 wire [7:0] led_override_i;
 
 

--- a/modules/hss_multiplexer/spio_hss_multiplexer_lfsr.v
+++ b/modules/hss_multiplexer/spio_hss_multiplexer_lfsr.v
@@ -115,16 +115,16 @@ module spio_hss_multiplexer_lfsr
 
   always @ (posedge clk or posedge rst)
     if (rst)
-      lfsr = 16'hffff;  // conventional initialization
+      lfsr <= 16'hffff;  // conventional initialization
     else
       if (next)
-        lfsr = nxt_lfsr;
+        lfsr <= nxt_lfsr;
 
   always @ (posedge clk or posedge rst)
     if (rst)
-      data_out = 16'h0000;  // conventional initialization
+      data_out <= 16'h0000;  // conventional initialization
     else
       if (next)
-        data_out = nxt_data;
+        data_out <= nxt_data;
   //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 endmodule

--- a/modules/spinnaker_link/spio_spinnaker_link_receiver.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_receiver.v
@@ -203,21 +203,6 @@ module flit_input_if
 
 
   //-------------------------------------------------------------
-  // 2-of-7 symbol detector (correct data, eop or error)
-  //-------------------------------------------------------------
-  function detect_2of7 ;
-    input [6:0] data;
-
-    case (data)
-      0, 1, 2, 4,
-      8, 16, 32,
-      64:         detect_2of7 = 0;  // incomplete (no/single-bit change)
-      default:    detect_2of7 = 1;  // correct data, eop or error
-    endcase
-  endfunction
-
-
-  //-------------------------------------------------------------
   // 2-of-7 data detector
   //-------------------------------------------------------------
   function data_2of7 ;

--- a/modules/spinnaker_link/spio_spinnaker_link_sender.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender.v
@@ -87,7 +87,6 @@ module spio_spinnaker_link_sender
   wire       synced_sl_ack;  // synchronized acknowledge input
 
   wire [6:0] flt_data;
-  wire       flt_eop;
   wire       flt_psz;
   wire       flt_vld;
   wire       flt_rdy;
@@ -101,7 +100,6 @@ module spio_spinnaker_link_sender
     .PKT_VLD_IN       (PKT_VLD_IN),
     .PKT_RDY_OUT      (PKT_RDY_OUT),
     .flt_data         (flt_data),
-    .flt_eop          (flt_eop),
     .flt_psz          (flt_psz),
     .flt_vld          (flt_vld),
     .flt_rdy          (flt_rdy)
@@ -117,7 +115,6 @@ module spio_spinnaker_link_sender
     .ACK_ERR_OUT      (ACK_ERR_OUT),
     .TMO_ERR_OUT      (TMO_ERR_OUT),
     .flt_data         (flt_data),
-    .flt_eop          (flt_eop),
     .flt_psz          (flt_psz),
     .flt_vld          (flt_vld),
     .flt_rdy          (flt_rdy),
@@ -148,7 +145,6 @@ module pkt_serializer
 
   // flit interface
   output reg              [6:0] flt_data,
-  output reg                    flt_eop,
   output reg                    flt_psz,
   output reg                    flt_vld,
   input                         flt_rdy
@@ -284,22 +280,6 @@ module pkt_serializer
 
 
   //-------------------------------------------------------------
-  // flit interface: generate flit end-of-packet flag
-  //-------------------------------------------------------------
-  always @(posedge CLK_IN or posedge RESET_IN)
-    if (RESET_IN)
-      flt_eop <= 1'b0;
-    else
-      case (state)
-        IDLE_ST: if (pkt_acpt && !flt_busy)
-                   flt_eop <= 1'b0;  // never eop
-	
-        default: if (!flt_busy)
-                   flt_eop <= eop;   // can be eop
-      endcase 
-
-
-  //-------------------------------------------------------------
   // flit interface: generate flit packet size flag
   //-------------------------------------------------------------
   always @(posedge CLK_IN or posedge RESET_IN)
@@ -398,7 +378,6 @@ module flit_output_if
 
   // packet serializer interface
   input      [6:0] flt_data,
-  input            flt_eop,
   input            flt_psz,
   input            flt_vld,
   output reg       flt_rdy,


### PR DESCRIPTION
Simple code clean up:

- dead code deleted.
- scrambler control register size fix.
- correct operator used for assignment to lfsr.
- added behavioural initialisation to debouncer module for simulation.
