### PR TITLE
New stac config

### DIFF
--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
@@ -39,21 +39,20 @@ localparam [(3*16*2)-1:0] FPGA_SL_TYPES = { // FPGA2
 // every SpiNNaker link type (0-5). This array stores the SpiNNkaker link
 // type connected to each FPGA link.
 // 3 FPGAs, 16 links per FPGA, 3 bits per link
-localparam [(3*16*3)-1:0] SPIN_LINK_TYPE = { // FPGA2
-                                             3'd1, 3'd0, 3'd1, 3'd0
-                                           , 3'd1, 3'd0, 3'd1, 3'd0
-                                           , 3'd1, 3'd2, 3'd1, 3'd2
-                                           , 3'd1, 3'd2, 3'd1, 3'd2
-                                             // FPGA1
-                                           , 3'd3, 3'd2, 3'd3, 3'd2
-                                           , 3'd3, 3'd2, 3'd3, 3'd2
-                                           , 3'd3, 3'd4, 3'd3, 3'd4
-                                           , 3'd3, 3'd4, 3'd3, 3'd4
-                                             // FPGA0
-                                           , 3'd5, 3'd4, 3'd5, 3'd4
-                                           , 3'd5, 3'd4, 3'd5, 3'd4
-                                           , 3'd5, 3'd0, 3'd5, 3'd0
-                                           , 3'd5, 3'd0, 3'd5, 3'd0
-                                           };
-
+localparam [(3*16*3)-1:0] SPIN_LINK_NUM = { // FPGA2
+                                            3'd1, 3'd0, 3'd1, 3'd0
+                                          , 3'd1, 3'd0, 3'd1, 3'd0
+                                          , 3'd1, 3'd2, 3'd1, 3'd2
+                                          , 3'd1, 3'd2, 3'd1, 3'd2
+                                            // FPGA1
+                                          , 3'd3, 3'd2, 3'd3, 3'd2
+                                          , 3'd3, 3'd2, 3'd3, 3'd2
+                                          , 3'd3, 3'd4, 3'd3, 3'd4
+                                          , 3'd3, 3'd4, 3'd3, 3'd4
+                                            // FPGA0
+                                          , 3'd5, 3'd4, 3'd5, 3'd4
+                                          , 3'd5, 3'd4, 3'd5, 3'd4
+                                          , 3'd5, 3'd0, 3'd5, 3'd0
+                                          , 3'd5, 3'd0, 3'd5, 3'd0
+                                          };
 `endif

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
@@ -14,83 +14,46 @@ localparam LOW_SL    = 2'b10;
 localparam HIGH_SL   = 2'b01;
 localparam UNUSED_SL = 2'b11;
 
-// The first 32 bits are for FPGA0, the next for FPGA1 and the last for FPGA2.
-// This is to work around the inability of some simulators to support literal
-// assignment to arrays.
-localparam [(32*3)-1:0] FPGA_SL_TYPES = { // FPGA2
-                                          LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
-                                        , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
-                                        , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
-                                        , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
-                                          // FPGA1
-                                        , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
-                                        , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
-                                        , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
-                                        , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
-                                          // FPGA0
-                                        , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
-                                        , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
-                                        , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
-                                        , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
-                                        };
+// The 32 least-significant bits are for FPGA0, the next for FPGA1 and the
+// last for FPGA2. This is to work around the inability of some simulators
+// to support literal assignment to arrays.
+// 3 FPGAs, 16 links per FPGA, 2 bits per link
+localparam [(3*16*2)-1:0] FPGA_SL_TYPES = { // FPGA2
+                                            LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
+                                          , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
+                                          , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
+                                          , LOW_SL,  LOW_SL,  LOW_SL,  LOW_SL
+                                            // FPGA1
+                                          , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
+                                          , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
+                                          , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
+                                          , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
+                                            // FPGA0
+                                          , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
+                                          , HIGH_SL, HIGH_SL, HIGH_SL, HIGH_SL
+                                          , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
+                                          , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
+                                          };
 
-// the back-pressure point (bpp) is different for each link
-// 3 FPGAs, 16 links per FPGA, 4 bits per link
-localparam [(3*16*4)-1:0] BPP = { // FPGA2
-                                  4'd6, 4'd7, 4'd6, 4'd7
-                                , 4'd6, 4'd7, 4'd6, 4'd7
-                                , 4'd6, 4'd9, 4'd6, 4'd9
-                                , 4'd6, 4'd9, 4'd6, 4'd9
-                                  // FPGA1
-                                , 4'd6, 4'd9, 4'd6, 4'd9
-                                , 4'd6, 4'd9, 4'd6, 4'd9
-                                , 4'd6, 4'd6, 4'd6, 4'd6
-                                , 4'd6, 4'd6, 4'd6, 4'd6
-                                  // FPGA0
-                                , 4'd5, 4'd6, 4'd5, 4'd6
-                                , 4'd5, 4'd6, 4'd5, 4'd6
-                                , 4'd5, 4'd7, 4'd5, 4'd7
-                                , 4'd5, 4'd7, 4'd5, 4'd7
-                                };
-
-// the number of "synchronous" flits before the back-pressure point
-// is different for each link
-// 3 FPGAs, 16 links per FPGA, 5 bits per link
-localparam [(3*16*5)-1:0] BSF_LONG = { // FPGA2
-                                       5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                       // FPGA1
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                     , 5'd17, 5'd17, 5'd17, 5'd17
-                                       // FPGA0
-                                     , 5'd15, 5'd17, 5'd15, 5'd17
-                                     , 5'd15, 5'd17, 5'd15, 5'd17
-                                     , 5'd15, 5'd17, 5'd15, 5'd17
-                                     , 5'd15, 5'd17, 5'd15, 5'd17
-                                     };
-
-// the number of "asynchronous" flits before the back-pressure point
-// is different for each link
+// the STAC configuration of the SpiNNaker link senders is different for
+// every SpiNNaker link type (0-5). This array stores the SpiNNkaker link
+// type connected to each FPGA link.
 // 3 FPGAs, 16 links per FPGA, 3 bits per link
-localparam [(3*16*3)-1:0] BAF_LONG = { // FPGA2
-                                       3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                       // FPGA1
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                     , 3'd2, 3'd2, 3'd2, 3'd2
-                                       // FPGA0
-                                     , 3'd4, 3'd2, 3'd4, 3'd2
-                                     , 3'd4, 3'd2, 3'd4, 3'd2
-                                     , 3'd4, 3'd2, 3'd4, 3'd2
-                                     , 3'd4, 3'd2, 3'd4, 3'd2
-                                     };
+localparam [(3*16*3)-1:0] SPIN_LINK_TYPE = { // FPGA2
+                                             3'd1, 3'd0, 3'd1, 3'd0
+                                           , 3'd1, 3'd0, 3'd1, 3'd0
+                                           , 3'd1, 3'd2, 3'd1, 3'd2
+                                           , 3'd1, 3'd2, 3'd1, 3'd2
+                                             // FPGA1
+                                           , 3'd3, 3'd2, 3'd3, 3'd2
+                                           , 3'd3, 3'd2, 3'd3, 3'd2
+                                           , 3'd3, 3'd4, 3'd3, 3'd4
+                                           , 3'd3, 3'd4, 3'd3, 3'd4
+                                             // FPGA0
+                                           , 3'd5, 3'd4, 3'd5, 3'd4
+                                           , 3'd5, 3'd4, 3'd5, 3'd4
+                                           , 3'd5, 3'd0, 3'd5, 3'd0
+                                           , 3'd5, 3'd0, 3'd5, 3'd0
+                                           };
 
 `endif

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.h
@@ -7,7 +7,7 @@
 `ifndef SPINNAKER_FPGAS_TOP_H
 `define SPINNAKER_FPGAS_TOP_H
 
-// In the below bit fields, 1=input, 0=output with the LSB corresponding to the
+// In the bit fields below, 1=input, 0=output with the LSB corresponding to the
 // SpiNNaker -> FPGA data pins and FPGA -> SpiNNaker ack pin and the MSB the
 // FPGA -> SpiNNaker data pins and SpiNNaker -> FPGA ack pin.
 localparam LOW_SL    = 2'b10;
@@ -35,9 +35,9 @@ localparam [(3*16*2)-1:0] FPGA_SL_TYPES = { // FPGA2
                                           , HIGH_SL, LOW_SL,  HIGH_SL, LOW_SL
                                           };
 
-// the STAC configuration of the SpiNNaker link senders is different for
-// every SpiNNaker link type (0-5). This array stores the SpiNNkaker link
-// type connected to each FPGA link.
+// the STAC configuration of each link sender depends on the connected
+// SpiNNaker link (0-5). This array stores the SpiNNkaker link
+// number connected to each FPGA link.
 // 3 FPGAs, 16 links per FPGA, 3 bits per link
 localparam [(3*16*3)-1:0] SPIN_LINK_NUM = { // FPGA2
                                             3'd1, 3'd0, 3'd1, 3'd0

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -1310,18 +1310,13 @@ generate for (i = 0; i < 16; i = i + 1)
 		wire                 slfc_pkt_txrdy_i;
 
 
-
 		// FPGA -> SpiNNaker
-		spio_spinnaker_link_sender
+		spio_spinnaker_link_sender #( .SL_TYPE          (SPIN_LINK_TYPE[(48*FPGA_ID) + (3*i)+:3]))
 		spio_spinnaker_link_sender_i( .CLK_IN           (spinnaker_link_clk0_i)
 		                            , .RESET_IN         (spinnaker_link_reset_i[(i*2) + 1])
 		                              // link error interface
 		                            , .ACK_ERR_OUT      (sl_tx_ack_err_i[i])
 		                            , .TMO_ERR_OUT      (sl_tx_tmo_err_i[i])
-		                              // back-pressure point interface
-		                            , .BPP_IN           (BPP[(64*FPGA_ID) + (4*i)+:4])
-		                            , .BSF_LONG_IN      (BSF_LONG[(80*FPGA_ID) + (5*i)+:5])
-		                            , .BAF_LONG_IN      (BAF_LONG[(48*FPGA_ID) + (3*i)+:3])
 		                              // Synchronous packet interface
 		                            , .PKT_DATA_IN      (slfc_pkt_txdata_i)
 		                            , .PKT_VLD_IN       (slfc_pkt_txvld_i)

--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -1311,7 +1311,7 @@ generate for (i = 0; i < 16; i = i + 1)
 
 
 		// FPGA -> SpiNNaker
-		spio_spinnaker_link_sender #( .SL_TYPE          (SPIN_LINK_TYPE[(48*FPGA_ID) + (3*i)+:3]))
+		spio_spinnaker_link_sender #( .SL_NUM           (SPIN_LINK_NUM[(48*FPGA_ID) + (3*i)+:3]))
 		spio_spinnaker_link_sender_i( .CLK_IN           (spinnaker_link_clk0_i)
 		                            , .RESET_IN         (spinnaker_link_reset_i[(i*2) + 1])
 		                              // link error interface

--- a/modules/spinnaker_link/spio_spinnaker_link_sender.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender.v
@@ -88,23 +88,17 @@ module spio_spinnaker_link_sender
   //---------------------------------------------------------------
   // the back-pressure point (bpp) is different for each SpiNNaker link
   // 6 links, 4 bits per link
-  localparam [(6*4)-1:0] BPP = { 4'd5, 4'd6, 4'd6
-                               , 4'd9, 4'd6, 4'd7
-                               };
+  localparam [(6*4)-1:0] BPP = {4'd5, 4'd6, 4'd6, 4'd9, 4'd6, 4'd7};
 
   // the number of "synchronous" flits before the back-pressure point
   // is different for each SpiNNaker link
   // 6 links, 5 bits per link
-  localparam [(6*5)-1:0] BSF_LONG = { 5'd15, 5'd17, 5'd17, 5'd17
-                                    , 5'd17, 5'd17, 5'd17, 5'd17
-                                    };
+  localparam [(6*5)-1:0] BSF_LONG = {5'd15, 5'd17, 5'd17, 5'd17, 5'd17, 5'd17};
 
   // the number of "asynchronous" flits before the back-pressure point
   // is different for each SpiNNaker link
   // 6 links, 3 bits per link
-  localparam [(6*3)-1:0] BAF_LONG = { 3'd4, 3'd2, 3'd2, 3'd2
-                                    , 3'd2, 3'd2, 3'd2, 3'd2
-                                    };
+  localparam [(6*3)-1:0] BAF_LONG = {3'd4, 3'd2, 3'd2, 3'd2, 3'd2, 3'd2};
 
 
   //-------------------------------------------------------------

--- a/modules/spinnaker_link/spio_spinnaker_link_sender.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender.v
@@ -86,17 +86,17 @@ module spio_spinnaker_link_sender
   //---------------------------------------------------------------
   // constants
   //---------------------------------------------------------------
-  // the back-pressure point (bpp) is different for each SpiNNaker link
+  // the back-pressure point (bpp) depends on the connected SpiNNaker link
   // 6 links, 4 bits per link
   localparam [(6*4)-1:0] BPP = {4'd5, 4'd6, 4'd6, 4'd9, 4'd6, 4'd7};
 
   // the number of "synchronous" flits before the back-pressure point
-  // is different for each SpiNNaker link
+  // depends on the connected SpiNNaker link
   // 6 links, 5 bits per link
   localparam [(6*5)-1:0] BSF_LONG = {5'd15, 5'd17, 5'd17, 5'd17, 5'd17, 5'd17};
 
   // the number of "asynchronous" flits before the back-pressure point
-  // is different for each SpiNNaker link
+  // depends on the connected SpiNNaker link
   // 6 links, 3 bits per link
   localparam [(6*3)-1:0] BAF_LONG = {3'd4, 3'd2, 3'd2, 3'd2, 3'd2, 3'd2};
 

--- a/modules/spinnaker_link/spio_spinnaker_link_sender.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender.v
@@ -62,8 +62,8 @@ module spio_spinnaker_link_sender
   // clock cycles to separate consecutive STAC flits
   parameter INTER_FLT_DELAY = 1,
 
-  // SpiNNaker link type (for back-pressure settings)
-  parameter SL_TYPE = 3
+  // SpiNNaker link number (for back-pressure settings)
+  parameter SL_NUM = 3
 )
 (
   input                        CLK_IN,
@@ -138,9 +138,9 @@ module spio_spinnaker_link_sender
   (
     .CLK_IN           (CLK_IN),
     .RESET_IN         (RESET_IN),
-    .BPP_IN           (BPP[(4*SL_TYPE)+:4]),
-    .BSF_LONG_IN      (BSF_LONG[(5*SL_TYPE)+:5]),
-    .BAF_LONG_IN      (BAF_LONG[(3*SL_TYPE)+:3]),
+    .BPP_IN           (BPP[(4*SL_NUM)+:4]),
+    .BSF_LONG_IN      (BSF_LONG[(5*SL_NUM)+:5]),
+    .BAF_LONG_IN      (BAF_LONG[(3*SL_NUM)+:3]),
     .ACK_ERR_OUT      (ACK_ERR_OUT),
     .TMO_ERR_OUT      (TMO_ERR_OUT),
     .flt_data         (flt_data),

--- a/modules/spinnaker_link/spio_spinnaker_link_sender_tb.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender_tb.v
@@ -31,7 +31,18 @@ module spio_spinnaker_link_sender_tb ();
 localparam UUT_CLK_HPER = (6.666 / 2);  // currently testing @ 150 MHz
 localparam TB_CLK_HPER  = (6.666 / 2);  // currently testing @ 150 MHz
 
- localparam SPL_HSDLY = 12;  // external link delay estimate
+localparam SPIN_LINK_TYPE = 3;
+
+// the back-pressure point (bpp) is different for each SpiNNaker link
+// 6 links, 4 bits per link
+localparam [(6*4)-1:0] BPP = { 4'd5, 4'd6, 4'd6
+                             , 4'd9, 4'd6, 4'd7
+                             };
+
+localparam BPP_TIME  = BPP[(4*SPIN_LINK_TYPE)+:4];
+localparam BPP_DELAY = 20;
+
+localparam SPL_HSDLY = 12;  // external link delay estimate
 //!! localparam SPL_HSDLY = 16;  // external link delay estimate
 //!!localparam SPL_HSDLY = 23;  // external link delay estimate (includes SpiNNaker)
 
@@ -39,12 +50,6 @@ localparam INIT_DELAY = (10 * TB_CLK_HPER);
 localparam RST_DELAY  = (51 * TB_CLK_HPER);  // align with clock posedge
 
 localparam COMB_DELAY = 2;
-
-localparam BPP_DELAY = 20;
-
-localparam BPP_UUT =  4'd6;
-localparam BSF_UUT = 5'd17;
-localparam BAF_UUT =  3'd2;
 
 
 //---------------------------------------------------------------
@@ -176,7 +181,10 @@ endfunction
 //---------------------------------------------------------------
 // unit under test
 //---------------------------------------------------------------
-spio_spinnaker_link_sender uut
+spio_spinnaker_link_sender
+#(
+  .SL_TYPE          (SPIN_LINK_TYPE)
+)  uut
 (
   .CLK_IN           (uut_clk),
   .RESET_IN         (uut_rst),
@@ -184,11 +192,6 @@ spio_spinnaker_link_sender uut
   // link error interface
   .ACK_ERR_OUT      (),
   .TMO_ERR_OUT      (),
-
-  // back-pressure point interface
-  .BPP_IN           (BPP_UUT),
-  .BSF_LONG_IN      (BSF_UUT),
-  .BAF_LONG_IN      (BAF_UUT),
 
   // incoming packet interface
   .PKT_DATA_IN      (uut_ipkt_data),
@@ -398,8 +401,9 @@ begin
     tb_old_data = uut_ospl_data;
 
     # SPL_HSDLY;
-    if (tb_flt_cnt == BPP_UUT) # BPP_DELAY;
-//!    if ((tb_flt_cnt != BPP_UUT) || (tb_pkt_cnt <= 10)) uut_ospl_ack = ~uut_ospl_ack;
+    // apply back pressure at the right time
+    if (tb_flt_cnt == BPP_TIME) # BPP_DELAY;
+//!    if ((tb_flt_cnt != BPP_TIME) || (tb_pkt_cnt <= 10)) uut_ospl_ack = ~uut_ospl_ack;
     uut_ospl_ack = ~uut_ospl_ack;
   end
 end

--- a/modules/spinnaker_link/spio_spinnaker_link_sender_tb.v
+++ b/modules/spinnaker_link/spio_spinnaker_link_sender_tb.v
@@ -31,7 +31,7 @@ module spio_spinnaker_link_sender_tb ();
 localparam UUT_CLK_HPER = (6.666 / 2);  // currently testing @ 150 MHz
 localparam TB_CLK_HPER  = (6.666 / 2);  // currently testing @ 150 MHz
 
-localparam SPIN_LINK_TYPE = 3;
+localparam SPIN_LINK_NUM = 3;
 
 // the back-pressure point (bpp) is different for each SpiNNaker link
 // 6 links, 4 bits per link
@@ -39,7 +39,7 @@ localparam [(6*4)-1:0] BPP = { 4'd5, 4'd6, 4'd6
                              , 4'd9, 4'd6, 4'd7
                              };
 
-localparam BPP_TIME  = BPP[(4*SPIN_LINK_TYPE)+:4];
+localparam BPP_TIME  = BPP[(4*SPIN_LINK_NUM)+:4];
 localparam BPP_DELAY = 20;
 
 localparam SPL_HSDLY = 12;  // external link delay estimate
@@ -183,7 +183,7 @@ endfunction
 //---------------------------------------------------------------
 spio_spinnaker_link_sender
 #(
-  .SL_TYPE          (SPIN_LINK_TYPE)
+  .SL_NUM           (SPIN_LINK_NUM)
 )  uut
 (
   .CLK_IN           (uut_clk),


### PR DESCRIPTION
This pull request involves no change in functionality.

This branch cleans up the STAC configuration mechanism. The top-level module no longer passes the STAC configuration parameters to the link sender module. Instead, it passes the SpiNNaker link number to which the link sender is connected. The link sender uses the SpiNNaker link number to configure the STAC parameters itself.

Note that the STAC configuration was passed through interface ports, which allowed run-time modification. The new mechanism passes the SpiNNaker link configuration as a compile-time parameter.
