### PR TITLE
Fix packet store ba pointer bug

### DIFF
--- a/modules/hss_multiplexer/spio_hss_multiplexer_pkt_store.v
+++ b/modules/hss_multiplexer/spio_hss_multiplexer_pkt_store.v
@@ -177,7 +177,7 @@ module spio_hss_multiplexer_pkt_store
       br <= nxt_br;
 
   always @ (*)
-    casex ({vld_nak, reading})
+    casex ({vld_nak, bpkt_gt})
         2'b1x:   nxt_br = seq_to_reg;  // nack'd frame
         2'b01:   nxt_br = br + 1;      // next in sequence
         default: nxt_br = br;          // no change!

--- a/version.h
+++ b/version.h
@@ -22,7 +22,7 @@
 `ifndef SPIO_VERSION_H
 `define SPIO_VERSION_H
 
-`define SPIO_VER_STR      "1.0.1"
-`define SPIO_VER_NUM      32'h00010001  // 32'h00MMmmpp
+`define SPIO_VER_STR      "1.0.2"
+`define SPIO_VER_NUM      32'h00010002  // 32'h00MMmmpp
 
 `endif


### PR DESCRIPTION
This pull request fixes the packet store bug documented in issue #39.

The solution is the one outlined in the issue: **br** update is done one clock cycle later.

The library version number is increased at the patch level as a result of the bug fix.