### PR TITLE
Add additional peripheral routing entries

### DIFF
--- a/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
+++ b/designs/spinnaker_fpgas/spinnaker_fpgas_top.v
@@ -1868,7 +1868,7 @@ generate if (INCLUDE_PERIPH_OUTPUT_SUPPORT)
                 // match remote configuration routing keys
                 assign rkey_matches_i = (sl_pkt_rxdata_i[PERIPH_OUTPUT_LINK][8+:32] & rc_mask_i) == rc_key_i;
                 
-                // match local configuration rotuing keys
+                // match local configuration routing keys
                 assign lkey_matches_i = (sl_pkt_rxdata_i[PERIPH_OUTPUT_LINK][8+:32] & lc_mask_i) == lc_key_i;
                 
                 // route packets according to key/mask settings

--- a/version.h
+++ b/version.h
@@ -22,7 +22,7 @@
 `ifndef SPIO_VERSION_H
 `define SPIO_VERSION_H
 
-`define SPIO_VER_STR      "1.1.0"
-`define SPIO_VER_NUM      32'h00010100  // 32'h00MMmmpp
+`define SPIO_VER_STR      "1.2.0"
+`define SPIO_VER_NUM      32'h00010200  // 32'h00MMmmpp
 
 `endif


### PR DESCRIPTION
This pull request adds 6 additional peripheral routing entries (routing key register + routing mask register).

This gives SpiNNaker applications more flexibility in the selection of SpiNNaker packet routing keys to send to peripherals. There are 6 distiller modules on spif, each associated with one of the new routing entries.

Six is an unusual number but, unfortunately, there is little space left on the SpiNNaker FPGAs and 8 entries would not fit.